### PR TITLE
Order of precedence, toString automatic brackets, and NOT operator

### DIFF
--- a/src/js/field-text-parser.js
+++ b/src/js/field-text-parser.js
@@ -164,11 +164,11 @@ define([
         };
 
         return methods;
-    }, {}));
-
-    module.NOT = function(left){
-        return left ? left.NOT() : module.Null;
-    }
+    }, {
+        NOT: function(left){
+            return left ? left.NOT() : module.Null;
+        }
+    }));
 
     return module;
 });

--- a/src/js/field-text-parser.js
+++ b/src/js/field-text-parser.js
@@ -87,25 +87,28 @@ define([
         }
     });
 
-    _.each([ExpressionNode.prototype, BracketedNode.prototype, BooleanNode.prototype], function(nodeType) {
+    var NegativeNode = function(node) {
+        this.fieldText = node;
+    };
+
+    _.each([ExpressionNode.prototype, BracketedNode.prototype, BooleanNode.prototype, NegativeNode.prototype], function(nodeType) {
         _.extend(nodeType, _.reduce(['AND', 'OR', 'XOR', 'BEFORE', 'AFTER'], function(methods, operator) {
             methods[operator] = function(right) {
                 return new BooleanNode(operator, this, right);
             };
 
             return methods;
-        }, {}));
+        }, {
+            NOT: function(){
+                return new NegativeNode(this);
+            }
+        }));
     });
 
-    var NegativeNode = function(node) {
+    NegativeNode.build = function(node) {
         var newNode = _.clone(node);
         delete newNode.negative;
-
-        this.fieldText = convert(newNode);
-    };
-
-    NegativeNode.build = function(node) {
-        return new NegativeNode(node);
+        return new NegativeNode(convert(newNode));
     };
 
     _.extend(NegativeNode.prototype, {
@@ -162,6 +165,10 @@ define([
 
         return methods;
     }, {}));
+
+    module.NOT = function(left){
+        return left ? left.NOT() : module.Null;
+    }
 
     return module;
 });

--- a/src/js/field-text-parser.js
+++ b/src/js/field-text-parser.js
@@ -4,10 +4,43 @@ define([
 ], function(_, parser) {
     "use strict";
 
+    // Order-of-precedence table as implemented in IDOL; according to Chris Rayson.
+    // The commented-out ones aren't currently implemented in this API, but are noted here for future reference.
+    // If implementing them, you'll need the numeric and negated forms as well, e.g. 'WHENN' and 'NOTWHEN'.
+    var priority = {
+        OR: 1,
+        XOR: 1,
+        // WNEAR: 1,
+        AND: 2,
+        // WHEN: 2,
+        // SENTENCE: 2,
+        // PARAGRAPH: 2,
+        BEFORE: 2,
+        AFTER: 2,
+        // NEAR: 3,
+        // DNEAR: 3,
+        // XNEAR: 3,
+        // YNEAR: 3,
+        NOT: 4,
+        BRACKETS: 5,
+        // EXPRESSION doesn't really exist in IDOL, just setting it to the max to simplify auto-bracket implementation.
+        EXPRESSION: 6
+    }
+
+    function bracket(child, parent) {
+        if (child.priority < parent.priority) {
+            // If we have a low-priority operator e.g. an OR nested inside a AND, then we should automatically add
+            //   brackets when printing it as a string so the tree will be interpreted correctly.
+            return '(' + child.toString() + ')';
+        }
+        return child.toString();
+    }
+
     var BooleanNode = function(operator, left, right) {
         this.operator = operator;
         this.left = left;
         this.right = right;
+        this.priority = priority[operator];
     };
 
     BooleanNode.build = function(node) {
@@ -16,7 +49,7 @@ define([
 
     _.extend(BooleanNode.prototype, {
         toString: function() {
-            return [this.left.toString(), this.operator, this.right.toString()].join(' ')
+            return [bracket(this.left, this), this.operator, bracket(this.right, this)].join(' ')
         }
     });
 
@@ -29,6 +62,7 @@ define([
     };
 
     _.extend(BracketedNode.prototype, {
+        priority: priority.BRACKETS,
         toString: function() {
             return '(' + this.fieldText.toString() + ')';
         }
@@ -45,6 +79,7 @@ define([
     };
 
     _.extend(ExpressionNode.prototype, {
+        priority: priority.EXPRESSION,
         toString: function() {
             return this.operator + '{' +
                 this.values.join(',') + '}' + ':' +
@@ -74,10 +109,11 @@ define([
     };
 
     _.extend(NegativeNode.prototype, {
+        priority: priority.NOT,
         negative: true,
 
         toString: function() {
-            return 'NOT ' + this.fieldText.toString();
+            return 'NOT ' + bracket(this.fieldText, this);
         }
     });
 

--- a/src/js/field-text.pegjs
+++ b/src/js/field-text.pegjs
@@ -1,47 +1,3 @@
-{
-    function leftAlign(left, boolean, right) {
-        if (right.boolean) {
-            return {
-                boolean: right.boolean,
-                left: leftAlign(left, boolean, right.left),
-                right: right.right
-            }
-        } else {
-            return {
-                boolean: boolean,
-                left: left,
-                right: right
-            }
-        }
-    }
-
-    function postProcess(input) {
-        var next = input.next;
-        delete input.next
-
-        if (!next) {
-            return input;
-        } else {
-            var boolean = next.boolean;
-            var right = next.right;
-
-            return leftAlign(input, boolean, right);
-        }
-    }
-
-    function postProcessNegation(input) {
-        var target = input;
-
-        while(target.left) {
-            target = target.left
-        }
-
-        target.negative = true;
-
-        return postProcess(input);
-    }
-}
-
 start
     = _ expr:ORExpression _ { return expr }
 
@@ -58,10 +14,10 @@ ORExpression
 
 ANDExpression
     = first:NOTExpression rest:( __ ANDBoolean __ NOTExpression)+    {
-             return rest.reduce(function(memo, curr) {
-                return {boolean: curr[1], left: memo, right: curr[3]};
-             }, first);
-         }
+         return rest.reduce(function(memo, curr) {
+            return {boolean: curr[1], left: memo, right: curr[3]};
+         }, first);
+     }
     / NOTExpression
 
 NOTExpression

--- a/src/js/field-text.pegjs
+++ b/src/js/field-text.pegjs
@@ -77,7 +77,7 @@ csvPrime
     / val:value { return [val]; }
 
 field
-    = chars:[A-Za-z0-9_]+ { return chars.join(''); }
+    = chars:[A-Za-z0-9_/]+ { return chars.join(''); }
 
 value
     = chars:[^,{}]+ { return chars.join(''); }

--- a/src/js/field-text.pegjs
+++ b/src/js/field-text.pegjs
@@ -78,6 +78,8 @@ ORBoolean
 
 ANDBoolean
     = 'AND'
+    / 'WHEN'
+    / 'BEFORE'
 
 colonsv
     = ':' head:field tail:colonsv { return [head].concat(tail); }

--- a/src/js/field-text.pegjs
+++ b/src/js/field-text.pegjs
@@ -75,6 +75,7 @@ fieldExpression
 ORBoolean
     = 'OR'
     / 'XOR'
+    / 'EOR' { return 'XOR' }
 
 ANDBoolean
     = 'AND'

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -263,6 +263,44 @@ define([
 
                 expect(result).toBe("NOT (MATCH{sodium cyanide,potassium chloride}:generic_poisons:bad_chemicals AND NOT MATCH{thousand island}:oil_based:salad_dressings) OR NOT EXISTS{}:fried_turnips");
             });
+
+            describe('should automatically add brackets', function() {
+                var one = new parser.ExpressionNode('MATCH', ['f1'], [1]);
+                var two = new parser.ExpressionNode('MATCH', ['f2'], [2]);
+                var three = new parser.ExpressionNode('MATCH', ['f3'], [3]);
+
+                it(' to OR nested in an AND', function() {
+                    var result = parser.AND(one,
+                        parser.OR(two, three)
+                    ).toString();
+
+                    expect(result).toBe('MATCH{1}:f1 AND (MATCH{2}:f2 OR MATCH{3}:f3)')
+                });
+
+                it(' to XOR nested in an AND', function() {
+                    var result = parser.AND(one,
+                        parser.XOR(two, three)
+                    ).toString();
+
+                    expect(result).toBe('MATCH{1}:f1 AND (MATCH{2}:f2 XOR MATCH{3}:f3)')
+                });
+
+                it(' to XOR nested in a BEFORE', function() {
+                    var result = parser.BEFORE(one,
+                        parser.XOR(two, three)
+                    ).toString();
+
+                    expect(result).toBe('MATCH{1}:f1 BEFORE (MATCH{2}:f2 XOR MATCH{3}:f3)')
+                });
+
+                it(' but not to AND nested in an OR', function() {
+                    var result = parser.OR(one,
+                        parser.AND(two, three)
+                    ).toString();
+
+                    expect(result).toBe('MATCH{1}:f1 OR MATCH{2}:f2 AND MATCH{3}:f3')
+                });
+            });
         });
     });
 });

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -23,6 +23,16 @@ define([
                     expect(result.fields).toContain("poisons1", "chemicals2");
                     expect(result.values).toContain("sodium cyanide", "potassium chloride");
                 });
+
+                it(', even if fieldnames contain slashes', function() {
+                    var fieldText = "MATCH{sodium cyanide,potassium chloride}:xml/path/poisons1:/other/path/chemicals2";
+
+                    var result = parser.parse(fieldText);
+
+                    expect(result.operator).toBe("MATCH");
+                    expect(result.fields).toContain("xml/path/poisons1", "/other/path/chemicals2");
+                    expect(result.values).toContain("sodium cyanide", "potassium chloride");
+                });
             });
 
             it('should match field text elements without field values', function() {

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -271,10 +271,18 @@ define([
                 expect(result).toBe("MATCH{sodium cyanide,potassium chloride}:generic_poisons:bad_chemicals XOR MATCH{thousand island}:oil_based:salad_dressings");
             });
 
+            it('should work on the NOT operator', function() {
+                var node = new parser.ExpressionNode('MATCH', ['f1'], [1]);
+                var result = parser.NOT(node).toString();
+
+                expect(result).toBe("NOT MATCH{1}:f1");
+            });
+
             describe('should automatically add brackets', function() {
                 var one = new parser.ExpressionNode('MATCH', ['f1'], [1]);
                 var two = new parser.ExpressionNode('MATCH', ['f2'], [2]);
                 var three = new parser.ExpressionNode('MATCH', ['f3'], [3]);
+                var four = new parser.ExpressionNode('MATCH', ['f4'], [4]);
 
                 it(' to OR nested in an AND', function() {
                     var result = parser.AND(one,
@@ -304,6 +312,24 @@ define([
                     var result = parser.OR(one, two).NOT().toString();
 
                     expect(result).toBe('NOT (MATCH{1}:f1 OR MATCH{2}:f2)')
+                });
+
+                it(' to inner ORs within an AND', function() {
+                    var result = parser.AND(
+                        one.OR(two),
+                        three.OR(four)
+                    ).toString();
+
+                    expect(result).toBe('(MATCH{1}:f1 OR MATCH{2}:f2) AND (MATCH{3}:f3 OR MATCH{4}:f4)')
+                });
+
+                it(' to only the first inner OR within an AND', function() {
+                    var result = parser.AND(
+                        one.OR(two).OR(three),
+                        four
+                    ).toString();
+
+                    expect(result).toBe('(MATCH{1}:f1 OR MATCH{2}:f2 OR MATCH{3}:f3) AND MATCH{4}:f4')
                 });
 
                 it(' but not to AND nested in an OR', function() {

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -179,6 +179,18 @@ define([
             });
 
             it('should expect boolean terms to be left-associative', function() {
+                var fieldText = "A{av}:af AND B{bv}:bf AND C{cv}:cf";
+
+                var result = parser.parse(fieldText);
+
+                expect(result.operator).toBe("AND");
+                expect(result.left.operator).toBe("AND");
+                expect(result.left.left.operator).toBe("A");
+                expect(result.left.right.operator).toBe("B");
+                expect(result.right.operator).toBe("C");
+            });
+
+            it('should expect boolean terms to have AND binding with higher precedence than OR', function() {
                 var fieldText = "A{av}:af AND B{bv}:bf OR C{cv}:cf";
 
                 var result = parser.parse(fieldText);
@@ -193,11 +205,11 @@ define([
 
                 result = parser.parse(fieldText);
 
-                expect(result.operator).toBe("AND");
-                expect(result.left.operator).toBe("OR");
-                expect(result.left.left.operator).toBe("A");
-                expect(result.left.right.operator).toBe("B");
-                expect(result.right.operator).toBe("C");
+                expect(result.operator).toBe("OR");
+                expect(result.left.operator).toBe("A");
+                expect(result.right.operator).toBe("AND");
+                expect(result.right.left.operator).toBe("B");
+                expect(result.right.right.operator).toBe("C");
             });
 
             it('should expect AND operator on tree structures to return the AND of those tree structures.', function() {

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -300,12 +300,24 @@ define([
                     expect(result).toBe('MATCH{1}:f1 BEFORE (MATCH{2}:f2 XOR MATCH{3}:f3)')
                 });
 
+                it(' to OR nested in a NOT', function() {
+                    var result = parser.OR(one, two).NOT().toString();
+
+                    expect(result).toBe('NOT (MATCH{1}:f1 OR MATCH{2}:f2)')
+                });
+
                 it(' but not to AND nested in an OR', function() {
                     var result = parser.OR(one,
                         parser.AND(two, three)
                     ).toString();
 
                     expect(result).toBe('MATCH{1}:f1 OR MATCH{2}:f2 AND MATCH{3}:f3')
+                });
+
+                it(' but not to a NOT nested in an OR', function() {
+                    var result = parser.OR(one.NOT(), two).toString();
+
+                    expect(result).toBe('NOT MATCH{1}:f1 OR MATCH{2}:f2')
                 });
             });
         });

--- a/test/js/spec/field-text-parser.js
+++ b/test/js/spec/field-text-parser.js
@@ -264,6 +264,13 @@ define([
                 expect(result).toBe("NOT (MATCH{sodium cyanide,potassium chloride}:generic_poisons:bad_chemicals AND NOT MATCH{thousand island}:oil_based:salad_dressings) OR NOT EXISTS{}:fried_turnips");
             });
 
+            it('should turn EOR to XOR', function() {
+                var fieldText = "MATCH{sodium cyanide,potassium chloride}:generic_poisons:bad_chemicals EOR MATCH{thousand island}:oil_based:salad_dressings";
+                var result = parser.parse(fieldText).toString();
+
+                expect(result).toBe("MATCH{sodium cyanide,potassium chloride}:generic_poisons:bad_chemicals XOR MATCH{thousand island}:oil_based:salad_dressings");
+            });
+
             describe('should automatically add brackets', function() {
                 var one = new parser.ExpressionNode('MATCH', ['f1'], [1]);
                 var two = new parser.ExpressionNode('MATCH', ['f2'], [2]);


### PR DESCRIPTION
This changes the parsing to account for IDOL's order-of-precedence rules (e.g. AND binds tighter than OR). It also changes the nodes so they should automatically add brackets if required by IDOL's precedence rules, e.g. 
```
  var one = new parser.ExpressionNode('MATCH', ['f1'], [1]);
  var two = new parser.ExpressionNode('MATCH', ['f2'], [2]);
  var three = new parser.ExpressionNode('MATCH', ['f3'], [3]);
  parser.AND(one, parser.OR(two, three)).toString();
```
should now give
  `MATCH{1}:f1 AND (MATCH{2}:f2 OR MATCH{3}:f3)`
instead of 
  `MATCH{1}:f1 AND MATCH{2}:f2 OR MATCH{3}:f3`
which would otherwise be interpreted as
  `(MATCH{1}:f1 AND MATCH{2}:f2) OR MATCH{3}:f3`
since AND binds tighter than OR. 
It also exposes a parser.NOT operator so you can negate the nodes using the external fieldtext API; and adds various tests for the new stuff. 